### PR TITLE
Add shape support for ports

### DIFF
--- a/ui/port_item.py
+++ b/ui/port_item.py
@@ -1,4 +1,3 @@
-from asyncio.unix_events import SelectorEventLoop
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsPathItem
 from PySide6.QtCore import QRectF, Qt
 from PySide6.QtGui import QBrush, QPainterPath, QPen, QColor


### PR DESCRIPTION
Here is the preview of my change UI-wise. I added different shape only for the Exec port for now.

<img width="841" height="338" alt="Jepretan layar_20260224_024624" src="https://github.com/user-attachments/assets/03afc11a-aa57-408d-b739-11b61c54a812" />

For this, I changed the base of `PortItem` from `QGraphicsEllipseItem` to `QGraphicsPathItem`, I suppose there shouldn't be any problem because of it, though it may add a tad bit of memory usage to contain the shape path definition.

In case there are some code style-related changes that you want me to fix or maybe adding more custom shapes for other type of ports, let me know.