### PR TITLE
Update and Extend Wiki

### DIFF
--- a/wiki/Contribute.md
+++ b/wiki/Contribute.md
@@ -1,0 +1,22 @@
+# Contributing
+## Coding
+Contributions are welcome! If you would like to contribute to Vish, please follow these steps:
+1. Fork the repository
+2. Create a new branch (`git checkout -b feature-branch`)
+3. Make your changes and commit them (`git commit -am 'Add new feature'`)
+4. Push to the branch (`git push origin feature-branch`)
+5. Create a new Pull Request
+6. Optional: Consider adding a screenshot of your work in the PR description.
+
+Note: Please ensure your code adheres to the existing coding style and includes appropriate tests.- This project is in active development. Features may change, and bugs may be present.
+
+## Translating
+An other way to contribute Vish is to help translating it in other languages. If you want to contribute to the translation of Vish, please follow these steps:
+1. Fork the repository
+2. Create a new branch (`git checkout -b translation-branch`)
+3. Create a new translation file in `assets/model/{language}.json` to add translations for the new language you want to add. **You can use the existing translations as a reference.**
+4. Add the translations for the new language in the newly created file (Use a basic translator if you don't know the language, but please try to be as accurate as possible) and make sure to include translations for the language name (e.g. "lang_en", "lang_fr", etc.) so that it can be displayed in the settings.
+5. Add the new language to the language combo box in `ui/settings.py` (You should update `_build_language_section` to add the new language to the combo box and also update `refresh_ui_texts` function to update the language name in the combo box when the language is changed with `update_combo_item` function)
+6. Commit your changes (`git commit -am 'Add translation for [Language]'`)
+7. Push to the branch (`git push origin translation-branch`)
+8. Create a new Pull Request

--- a/wiki/DeveloperGuide.md
+++ b/wiki/DeveloperGuide.md
@@ -1,0 +1,36 @@
+# Developer Guide
+
+## General 
+The Application is written using Python3 and the PySide6 (Qt) UI libary.
+Before running the application make sure PySide6 is installed. (`pip install pyside6`)
+
+## Branching
+New features, bugfixes and translations should be developed on separate branches.
+Note: The repo uses "Squash and Merge" on Pull Requests, so the number ob commits on a development branch does not affect the resulting Commit on `master`. Feel free to change/revise committed implementations as much as you like.
+
+## Translation
+All texts that are visible in the UI should be translated. If you add a new text element use the `Traduction.get_trad(key, value)` method to get the displayed text and add corresponding translation keys to the language specific json files in `assests/models/*.json` instead of hard coding the text string. 
+Please Note: While you are not required to translate all texts you've added into all languages please create a translation issue after your PR has been merged.
+
+## Creating a new Node
+A standard note consits of a node_type, category, label and description. To create a new node the folling points have to be kept in mind:
+1. The `node_type` and `label` must be the same in `@register_node()` and `super().__init__()`
+2. A node class must ultimatily be derivied from `BaseNode` (e.g. math operation inherits from `MathNode` which inherits from `BaseNode`)
+3. Each type of node should have a distinct color (exeception: same functionalliy but diffent Port Types (e.g. equals))
+4. Each Port should have a tooltip
+
+```python
+@register_node("string_constant", category="Constants", label="String Constant", description="Represents a string constant value")
+class StringConstantNode(BaseNode):
+    def __init__(self):
+        super().__init__("string_constant", "String Constant", "#BDC3C7")
+        self.add_output("Value", PortType.STRING, "String value")
+        self.properties["value"] = ""
+
+    def emit_bash_value(self, context: BashContext) -> str:
+        return f'"{self.properties.get("value", "")}"'
+```
+
+# References
+
+* [PySide6 documentation](https://doc.qt.io/qtforpython-6/index.html)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,42 @@
+# Visual Bash Scripting Wiki
+## Introduction
+### Presentation
+Welcome to the Vish wiki, here you'll find documentation and resources to help you get started with Visual Bash Editor (Vish). Vish is a graphical editor for creating and managing Bash scripts using a node-based interface. It allows users to visually design their scripts by connecting various nodes that represent different Bash commands and constructs.
+### Target Audience
+Vish is designed for both beginners and experienced Bash script writers who want to visualize and simplify the process of creating Bash scripts. It is particularly useful for those who prefer a graphical approach to scripting or want to learn Bash scripting concepts in a more intuitive way.
+## Node Notation Convention
+
+To simplify discussions about existing and new nodes, Vish uses a standardized node signature notation.
+
+The format is:
+`<Inputs> - <Outputs>`
+
+Each side describes the number and type of pins using the following identifiers:
+
+| Identifier | Type |
+|------------|------|
+| E | Execution / Control Flow |
+| S | String |
+| I | Integer |
+| B | Boolean |
+| P | Path |
+| V | Variable |
+| C | Condition |
+| n |	any number possible | 
+| m |	minimum required number |
+| x |	maximum allowed number |
+| a |	Array |
+
+### Examples
+
+- `1S-2S` → 1 String input, 2 String outputs  
+- `1E-3E` → 1 Execution input, 3 Execution outputs  
+- `2S1I-1S` → 2 String inputs, 1 Integer input, 1 String output
+- `1E-nE` → 1 Execution input, Any number of outputs possible.
+
+This notation is used for <ins>**documentation and design discussions only**</ins>.  
+It reflects the internal type system and ensures consistency across the project.
+
+## Futher Links
+- [[How to Contribute|Contribute]]
+- [[Developer Guide|DeveloperGuide]]


### PR DESCRIPTION
As the Wiki cannot have PR directly you can close the PR without merge if accepted and copied manually

I've extended the Node Notation Syntax by the latest changes from README.md and also copied the Contributing section into the wiki. We could now replace the whole section with a link to the Wiki.

I've also added a small Developer Guide on how to get started and what to keep in mind