### PR TITLE
Nix flakes implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Nix stuff:
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { nixpkgs, ... } @ inputs:
+  outputs = { self, nixpkgs, ... } @ inputs:
   let
     supportedSystems = [
       "aarch64-darwin"
@@ -86,6 +86,11 @@
       }
     );
   in
+  {
+    overlays.default = final: prev: {
+      vish = self.packages.${prev.stdenv.hostPlatform.system}.vish;
+    };
+  } //
   forAllSystems supportedSystems (
     { pkgs, ... }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,120 @@
+{
+  description = "Vish is a graphical editor for creating and managing Bash scripts using a node-based interface";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { nixpkgs, ... } @ inputs:
+  let
+    supportedSystems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+
+    forAllSystems = (systems: perSystemFlake:
+      builtins.foldl' (acc: system:
+        let
+          inputs' = {
+            pkgs = nixpkgs.legacyPackages.${system};
+          };
+
+          systemWrapper = (attr: set: { ${system} = set; });
+        in
+        acc // (builtins.mapAttrs systemWrapper (perSystemFlake inputs'))
+      ) {} systems
+    );
+
+    vish = (
+      {
+        makeWrapper,
+        stdenv,
+        lib,
+        meson,
+        ninja,
+        python3,
+        qt6,
+      }:
+      let
+        python = python3.withPackages (python-pkgs: (with python-pkgs; [
+          pyside6
+          shiboken6
+        ]));
+
+      inherit (qt6)
+        qtbase
+        wrapQtAppsHook
+        ;
+      in
+      stdenv.mkDerivation {
+        pname = "vish";
+        version = lib.fileContents ./VERSION;
+
+        src = lib.fileset.toSource {
+          root    = ./.;
+          fileset = lib.fileset.gitTracked ./.;
+        };
+
+        buildInputs = [
+          makeWrapper
+          meson
+          ninja
+          python
+          qtbase
+        ];
+
+        nativeBuildInputs = [
+          wrapQtAppsHook
+        ];
+
+        postInstall = ''
+          makeWrapper '${python}/bin/python3' "$out/bin/vish" \
+            --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}" \
+            --add-flag "$out/share/vish/main.py"
+        '';
+
+        meta = {
+          description = "Vish is a graphical editor for creating and managing Bash scripts using a node-based interface";
+          homepage = "https://github.com/Lluciocc/Vish";
+          license = lib.licenses.mit;
+          sourceProvenance = with lib.sourceTypes; [ fromSource ];
+          mainProgram = "vish";
+          platforms = supportedSystems;
+        };
+      }
+    );
+  in
+  forAllSystems supportedSystems (
+    { pkgs, ... }:
+    let
+      package = pkgs.callPackage vish {};
+      app = {
+        type = "app";
+        program = "${package}/bin/vish";
+        inherit (package) meta;
+      };
+      shell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          python3Packages.virtualenv
+          python3Packages.pyside6
+          python3Packages.shiboken6
+          qt6.qtbase
+        ];
+        shellHook = ''
+          export QT_PLUGIN_PATH="${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}":$QT_PLUGIN_PATH
+        '';
+      };
+    in
+    {
+      packages.vish    = package;
+      packages.default = package;
+
+      apps.vish     = app;
+      apps.default  = app;
+
+      devShells.default = shell;
+    }
+  );
+}


### PR DESCRIPTION
# Motive for this PR
I admire the purpose of educational projects such as Vish, so I am in favor of making it easily accessible on as many systems as possible. And this is one way I can help with it.
NixOS is certainly not a distro for Linux beginners. But the nix tool is available for other Linux distros and even macOS, so I'd argue it's worth the effort of making Vish more easily accessible for those who use nix.

# Features
This PR adds support for the following features of Nix Flakes:
- `nix run`;
- `nix profile add`;
- `nix build`;
- `nix develop`;
- nix overlays;

## Running
It would make possible to directly run the project with the command:
```bash
nix run github:Lluciocc/Vish
```

## Installing
It would be possible to install Vish with the (not declarative) command:
```bash
nix profile add github:Lluciocc/Vish
```
But it would also be possible to install it declaratively using NixOS or Home Manager with flakes enabled using nix overlays. It could look something like this:
```nix
# flake.nix
{
    inputs = {
        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
        vish = {
            url = "github:Lluciocc/Vish";
            inputs.nixpkgs.follows = "nixpkgs";
        };
        # for home manager configuration
        home-manager = {
            url = "github:nix-community/home-manager/master";
            inputs.nixpkgs.follows = "nixpkgs";
        };
        ...
    };
    ...
    outputs = { nixpkgs, ... } @ inputs: {
        # for nixos configuration
        nixosConfiguration.user = nixpkgs.lib.nixosSystem {
            ...
            specialArgs = { inherit inputs; };
            ...
        }
        ...
        # for home manager configuration
        homeConfigurations.user = home-manager.lib.homeManagerConfiguration {
            ...
            extraSpecialArgs = { inherit inputs; };
            ...
        }
        ...
    }
}
```
```nix
# main nix file
{ inputs, pkgs, ... }:
    ...
    nixpkgs.overlays = [ inputs.vish.overlays.default ];
    ...
    # local user install with nixos configuration
    users.users.user.packages = [ pkgs.vish ];
    ...
    # install with home manager
    home.packages = [ pkgs.vish ];
    ...
}
```

## Development
This change is for anyone that wants to develop with Nix Flakes. It doesn't make it mandatory for every contributor to use nix, it just makes some things easier for those that want to use it.
At the project root folder, it's possible to generate the runnable file `./result/bin/vish` with the command:
```bash
nix build
```
At the project root, it's possible to enter a shell with all dependencies and configuration necessary to run `python3 ./main.py` with the command:
```bash
nix develop
```

# Implementation details
## How does Nix know the project version?
I wrote `flake.nix` so that nix knows the version of the project using the file `./VERSION`.

## Supported Systems
Technically it would be possible to use the features of this PR on `x86_64` and `aarch64` architectures on both Linux and macOS, but I can only test it on Linux `x86_64`.

# Future Maintenance
There's still some stuff to consider implementing, like a nixos module and a home manager module in the project's flake. But it's open for discussion if it's really that necessary.
There's still the need to test this PR on nix-darwin (macOS), so that might require some more tinkering. But it should work on most linux with nix.
If this PR is accepted and the maintainers agree, I can become the contributor responsible for maintaining nix flakes for this project.
