### PR TITLE
improve header comment

### DIFF
--- a/core/bash_emitter.py
+++ b/core/bash_emitter.py
@@ -13,7 +13,8 @@ class BashEmitter:
         header = [
             "#!/bin/bash/env bash",
             "",
-            "# Generated from Visual Bash Editor",
+            "# Generated with Visual Bash Editor",
+            "",
             ""
         ]
         if Config.CUSTOM_SHEBANG:


### PR DESCRIPTION
Two minor improvement for the header.
1) Comment sounds more professional with `with`.
2) For some reason the generator ignores the empty line beyond the comment, so I added another line which does the job just fine. 