### PR TITLE
Fix Formating on shortcuts page

### DIFF
--- a/ui/keyboard_shortcuts.py
+++ b/ui/keyboard_shortcuts.py
@@ -41,6 +41,7 @@ SHORTCUTS = {
         "items": [
             (["Ctrl", "LB"], "shortcut_reconnection_mode"),
             (["Alt", "LB"], "shortcut_removing_mode"),
+            (["Ctrl", "MB"], "shortcut_reset_zoom"),
             (["C"], "shortcut_comment_box"),
             (["F"], "shortcut_auto_layout"),
             (["R"], "shortcut_rebuild_graph"),


### PR DESCRIPTION
1) `Alt`, `Num+`, `Num-` got a large button. `Num-` is a square button on real keyboards, but for readability the larger button is required.
2) `F9` fixed, wrong brackets used.
3) Spacing for Graph fixed. It is not counting the keys, but the spaces between keys (1 key, 0 spacers; 2 keys, 1 spacer and so  on).
4) Added missing shortcut for resetting zoom.