### PR TITLE
Maximize Modals on Mobile Devices

### DIFF
--- a/core/debug.py
+++ b/core/debug.py
@@ -89,7 +89,7 @@ class Info:
         physical_height = screen.size().height() / dpi
         physical_diagonal = (physical_width ** 2 + physical_height ** 2) ** 0.5
 
-        if physical_diagonal <= 7:
+        if physical_diagonal <= 7.5:
             device_type = "phone"
         else:
             device_type = "desktop"

--- a/core/debug.py
+++ b/core/debug.py
@@ -1,11 +1,12 @@
-import os
+from core.logger import Logger
 from pathlib import Path
+from PySide6.QtCore import QStandardPaths
+from PySide6.QtGui import QGuiApplication
+from ui.info import MessageWidget
+import getpass
+import os
 import platform
 import sys
-import getpass
-from ui.info import MessageWidget
-from PySide6.QtCore import QStandardPaths
-from core.logger import Logger
 
 class Debug:
     _parent = None
@@ -78,3 +79,18 @@ class Info:
     @staticmethod
     def get_user():
          return getpass.getuser()
+
+    @staticmethod
+    def get_device_type():
+        screen = QGuiApplication.primaryScreen()
+        dpi = screen.physicalDotsPerInch()
+
+        physical_width = screen.size().width() / dpi
+        physical_height = screen.size().height() / dpi
+        physical_diagonal = (physical_width ** 2 + physical_height ** 2) ** 0.5
+
+        if physical_diagonal <= 7:
+            device_type = "phone"
+        else:
+            device_type = "desktop"
+        return device_type

--- a/ui/about/about.py
+++ b/ui/about/about.py
@@ -1,13 +1,9 @@
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout,
-    QPushButton, QStackedWidget, QGraphicsOpacityEffect
-)
-from PySide6.QtCore import (
-    Qt, QPoint, QPropertyAnimation, QEasingCurve
-)
-from theme.theme import Theme
-from core.traduction import Traduction
 from core.config import MarkdownLoader
+from core.debug import Info
+from core.traduction import Traduction
+from PySide6.QtCore import QEasingCurve, QPoint, QPropertyAnimation, Qt
+from PySide6.QtWidgets import QDialog, QGraphicsOpacityEffect, QHBoxLayout, QPushButton, QStackedWidget, QVBoxLayout
+from theme.theme import Theme
 from ui.about.about_pages import AboutMainPage, AboutTextPage
 
 class AboutDialog(QDialog):
@@ -15,7 +11,10 @@ class AboutDialog(QDialog):
         super().__init__(parent)
 
         self.setModal(True)
-        self.resize(440, 520)
+        if Info.get_device_type() == "phone":
+            self.showMaximized()
+        else:
+            self.resize(440, 520)
         self.setWindowTitle(Traduction.get_trad("about", "About"))
 
         self.current_index = 0

--- a/ui/keyboard_shortcuts.py
+++ b/ui/keyboard_shortcuts.py
@@ -136,7 +136,10 @@ class KeyboardShortcutsDialog(QDialog):
 
         self.setWindowTitle(Traduction.get_trad("keyboard_shortcuts", "Keyboard Shortcuts"))
         self.setModal(True)
-        self.resize(980, 560)
+        if Info.get_device_type() == "phone":
+            self.showMaximized()
+        else:
+            self.resize(980, 560)
 
         self.setStyleSheet(f"""
             QDialog {{

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -11,7 +11,7 @@ from core.traduction import Traduction
 from theme.theme import set_dark_theme, set_purple_theme, set_white_theme
 from theme.theme_parser import load_theme, import_theme, delete_theme, theme_list, BUILTIN_THEMES, _themes_dir, parse_yaml
 from ui.menu_style import apply_menu_style, apply_btn_style
-from core.debug import Debug
+from core.debug import Debug, Info
 
 def set_config_bool(attr_name: str, value: bool) -> None:
     if not hasattr(Config, attr_name):
@@ -47,7 +47,10 @@ class SettingsDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setModal(True)
-        self.setFixedWidth(380)
+        if Info.get_device_type() == "phone":
+            self.showMaximized()
+        else:
+            self.setFixedWidth(380)
 
         self.layout = QVBoxLayout(self)
         self.layout.setSpacing(12)

--- a/ui/welcome.py
+++ b/ui/welcome.py
@@ -178,7 +178,10 @@ class WelcomeScreen(QDialog):
         self.setWindowTitle("  ")
         self.setModal(True)
         self.setMinimumSize(360, 294)
-        self.setFixedSize(620, 480)
+        if Info.get_device_type == "phone":
+            self.showMaximized()
+        else:
+            self.setFixedSize(620, 480)
 
         self.setStyleSheet(f"""
             QDialog {{

--- a/ui/welcome.py
+++ b/ui/welcome.py
@@ -178,7 +178,7 @@ class WelcomeScreen(QDialog):
         self.setWindowTitle("  ")
         self.setModal(True)
         self.setMinimumSize(360, 294)
-        if Info.get_device_type == "phone":
+        if Info.get_device_type() == "phone":
             self.showMaximized()
         else:
             self.setFixedSize(620, 480)


### PR DESCRIPTION
Debug Info now has a selector between `desktop` or `phone` device which can be used to do actions specific to this device. The selector calculates the physical screen size and everything with 7.5" or below is defined as "phone", everything else as desktop. The biggest smartphone screen size I found online was 7.2". While it does not run Linux, it gives an idea how big Linuxphones could become in future. Even if it is no phone, screen size probably matters most. 

Hint: To my knowledge there is not foldable Linux phone, so I do not care for any edge-cases with such devices, yet. If it matters in future, affected people can open an issue.

On phone devices, the modals welcome, settings, keyboard shortcuts and about are opened maximized. On desktop nothing changes. This already solves some of the major display issues where parts of the window did not fill the screen and other parts clip out of screen bounds. Further improvements require modal/window specific changes, which has no priority, yet.

All windows can display the whole content in landscape or in portrait orientation. Most of them do not fit in both orientations, but at least they are usable after this merge.