### PR TITLE
Replace Math Method

### DIFF
--- a/ui/edge_item.py
+++ b/ui/edge_item.py
@@ -3,7 +3,6 @@ from PySide6.QtCore import QPointF, Qt
 from PySide6.QtGui import QPainterPath, QPen, QColor
 from core.graph import Edge
 from core.port_types import PORT_STYLES, PortType
-import math
 
 class EdgeItem(QGraphicsPathItem):
     def __init__(self, edge=None, source_port=None, target_port=None):
@@ -66,7 +65,7 @@ class EdgeItem(QGraphicsPathItem):
         
         dx = self.target_pos.x() - self.source_pos.x()
         dy = self.target_pos.y() - self.source_pos.y()
-        d_str = math.sqrt(dx ** 2 + dy ** 2) * 1.35
+        d_str = (dx ** 2 + dy ** 2) ** 0.5 * 1.35
 
         ctrl1_x = self.source_pos.x() + min(d_str, max(dx, pow(abs(dx), 0.8) + 250)) * 0.5
         ctrl1_y = self.source_pos.y()


### PR DESCRIPTION
Previously I used import math to call a square root function. But it is the same as `x^0.5`, so I can remove the math function and just call the exponential function, which is build in natively. This makes the code little bit cleaner. It has no impact on the edge visual behavior.