### PR TITLE
Final Node Teleport Fix

### DIFF
--- a/ui/comment_box.py
+++ b/ui/comment_box.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QGraphicsRectItem, QGraphicsTextItem, QGraphicsItem, QMenu
+from PySide6.QtWidgets import QGraphicsRectItem, QGraphicsTextItem, QGraphicsItem, QMenu, QGraphicsView
 from PySide6.QtCore import Qt, QRectF, QPointF, QSizeF
 from PySide6.QtGui import QCursor, QPen, QColor, QPainter, QBrush, QPainterPath, QLinearGradient, QFont, QKeySequence
 from commands.undo_commands import *
@@ -304,7 +304,8 @@ class CommentBoxItem(QGraphicsRectItem):
         if not self._in_header(event.pos()):
             if self.scene() and self.scene().views():
                 view = self.scene().views()[0]
-
+                
+                view.setDragMode(QGraphicsView.NoDrag)
                 scene_pos = event.scenePos()
                 view.show_node_palette(scene_pos)
 

--- a/ui/graph_view.py
+++ b/ui/graph_view.py
@@ -757,8 +757,6 @@ class GraphView(QGraphicsView):
         node.y = source_rect.center().y()
 
         self.undo_stack.push(AddNodeCommand(self, node))
-        self.undo_stack.undo()
-        self.undo_stack.redo()
 
         new_node_item = self.node_items.get(node.id)
         if not new_node_item:

--- a/ui/graph_view.py
+++ b/ui/graph_view.py
@@ -134,8 +134,6 @@ class GraphView(QGraphicsView):
         node.y = scene_pos.y()
 
         self.undo_stack.push(AddNodeCommand(self, node))
-        self.undo_stack.undo()
-        self.undo_stack.redo()
         node_item = self.node_items.get(node.id)
 
 


### PR DESCRIPTION
I removed the undo-redo "teleport fix", because it caused an issue with my recent changes. A removal was required that my work is functional. And it was no clean solution anyway.

I fixed that bug in `comment_box.py` and could not trigger it again.