### PR TITLE
Fixing edge bugs

### DIFF
--- a/ui/graph_scene.py
+++ b/ui/graph_scene.py
@@ -68,15 +68,17 @@ class GraphScene(QGraphicsScene):                                          #TODO
             self.new_edge(first_port)
 
     def new_edge(self, first_port):
+        drag_edge = self.initialize_edge(first_port)
+        drag_edge.target_pos = first_port.center_scene_pos()
+        drag_edge.update_positions()
+        self.drag_edges.append(drag_edge)
+
+    def initialize_edge(self, first_port):
         drag_edge = EdgeItem()
         drag_edge.source_port = first_port
         drag_edge.apply_style_from_source()
-
         self.addItem(drag_edge)
-        drag_edge.target_pos = first_port.center_scene_pos()
-        drag_edge.update_positions()
-
-        self.drag_edges.append(drag_edge)
+        return drag_edge
 
     def delete_edges(self): # Only edges in self.drag_edges become deleted!
         for edge in self.drag_edges:
@@ -141,7 +143,7 @@ class GraphScene(QGraphicsScene):                                          #TODO
                 edge = self.graph.update_edge(edge.edge.id, edge.source_port.port, edge.target_port.port)
 
                 if Config.DEBUG:
-                    Logger.LogMessage(f"GRAPH.ADD_EDGE returned: {edge}")
+                    Logger.LogMessage(f"GRAPH.UPDATE_EDGE returned: {edge}")
 
             second_port.edges.clear()
             for edge in self.pending_edges:
@@ -154,7 +156,7 @@ class GraphScene(QGraphicsScene):                                          #TODO
                 edge = self.graph.update_edge(edge.edge.id, edge.source_port.port, edge.target_port.port)
 
                 if Config.DEBUG:
-                    Logger.LogMessage(f"GRAPH.ADD_EDGE returned: {edge}")
+                    Logger.LogMessage(f"GRAPH.UPDATE_EDGE returned: {edge}")
 
             self.pending_edges.clear()
 
@@ -221,10 +223,13 @@ class GraphScene(QGraphicsScene):                                          #TODO
             modifier = QApplication.keyboardModifiers()
             if second_port.edges:
                 if modifier == Qt.AltModifier:          # Deleting previous edges (Alt)
-                    self.pending_edges = self.drag_edges
-                    self.drag_edges = second_port.edges
-                    self.delete_edges()
-                    self.drag_edges = self.pending_edges
+                    if first_port.port.port_type == second_port.port.port_type:
+                        self.pending_edges = self.drag_edges
+                        self.drag_edges = second_port.edges
+                        self.delete_edges()
+                        self.drag_edges = self.pending_edges
+                    else:
+                        self.restore_pending_connection()
 
 
             if self.pending_port:                       # Check for self-connection on multi-dragging
@@ -280,6 +285,9 @@ class GraphScene(QGraphicsScene):                                          #TODO
             else:
                 self._show_invalid_feedback(first_port, second_port)
             return
+
+        if not drag_edge:
+            drag_edge = self.initialize_edge(first_port)
 
         if self.pending_port:
             if self.pending_port.is_input:

--- a/ui/graph_scene.py
+++ b/ui/graph_scene.py
@@ -264,6 +264,7 @@ class GraphScene(QGraphicsScene):                                          #TODO
                             self.restore_pending_connection()
 
                 else:                                   # LB, ignoring modifier
+                    self.is_ctrl = False
                     if first_port.is_input == (first_port.is_input == second_port.is_input): # XNOR operator
                         self.set_edge(drag_edge.source_port, second_port, drag_edge)
                     else:

--- a/ui/graph_view.py
+++ b/ui/graph_view.py
@@ -736,9 +736,8 @@ class GraphView(QGraphicsView):
                 target_input = p
                 break
 
-        if source_output and target_input:                                      #TODO outdated code
-            self.graph_scene.start_connection(source_output)
-            self.graph_scene.finalize_connection(source_output, target_input)
+        if source_output and target_input:
+            self.graph_scene.set_edge(source_output, target_input, None)
 
         self.close_node_palette()
 


### PR DESCRIPTION
1. Fixing an error when `Ctrl` + `Space` added a new node.
1. Fixing a bug that could result in the issue you can see on image below when using the `Alt`-edge-deletion functionality.
1. Fixing a bug when `Ctrl` functionality allows to connect incompatible port types, similar as image below.

<img width="639" height="193" alt="Result of an Alt-deletion bug." src="https://github.com/user-attachments/assets/bd452ab2-9b7a-4211-a110-b3833d38663b" />
