### PR TITLE
Logger: Anonymize Directory Path Names

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -56,5 +56,5 @@ class Logger:
 
     @staticmethod
     def anonymize(message: str):
-        message = message.replace(f"{Path.home()}", "[user_dir]")
+        message = message.replace(f"{Path.home()}", "~")
         return message

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,5 +1,5 @@
-import datetime
 from pathlib import Path
+import datetime
 
 class Colors:
     RESET  = "\033[0m"
@@ -25,14 +25,17 @@ class Logger:
 
     @staticmethod
     def LogMessage(message: str):
+        message = Logger.anonymize(message)
         Logger._log("INFO", message, Colors.CYAN)
 
     @staticmethod
     def LogWarning(message: str):
+        message = Logger.anonymize(message)
         Logger._log("WARN", message, Colors.YELLOW)
 
     @staticmethod
     def LogError(message: str):
+        message = Logger.anonymize(message)
         Logger._log("ERROR", message, Colors.RED)
 
     @staticmethod
@@ -50,3 +53,8 @@ class Logger:
                 f.write(f"\n{message_error}")
 
         Logger.LogMessage(f"Logged messages saved to {log_path}")
+
+    @staticmethod
+    def anonymize(message: str):
+        message = message.replace(f"{Path.home()}", "[user_dir]")
+        return message


### PR DESCRIPTION
When users share their logs online, their username will be exposed as soon as the log contains a file-path. This patch replaces the path-to-home-directory with `~`. 

Example: 
old
`[INFO] Loaded project from /home/Lain Iwakura/.config/vish/projects/All Nodes/graph.json with 39 nodes and 9 edges.`
to new
`[INFO] Loaded project from ~/.config/vish/projects/All Nodes/graph.json with 39 nodes and 9 edges.`