### PR TITLE
Fixing error when creating node with invalide connection

### DIFF
--- a/ui/graph_view.py
+++ b/ui/graph_view.py
@@ -166,7 +166,8 @@ class GraphView(QGraphicsView):
                         scene.set_edge(valid_port, edge.source_port, edge)
                 scene.drag_edges.clear()
             else:
-                scene._cancel_drag_edge()
+                scene.restore_pending_connection()
+                scene.drag_edges.clear()
 
         self.close_node_palette()
 


### PR DESCRIPTION
Drag an edge from start node and create a new node without execution pin. This leads to an error and unexpected behavior. Commit fixes it.