### PR TITLE
docs: add troubleshooting guide for PySide6 Flatpak runtime issues

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,36 @@
+# PR description
+
+## Summary
+
+This PR adds troubleshooting documentation and optional helper scripts for a Flatpak runtime issue that may prevent Vish from starting due to PySide6 import failures.
+
+Users affected by the issue may see errors such as:
+
+```text
+ImportError: could not import module 'PySide6.QtGui'
+```
+
+or:
+
+```text
+ImportError: could not import module 'PySide6.QtCore'
+```
+
+## Changes
+
+- Added `docs/troubleshooting.md`
+- Added `scripts/fix-pyside6-runtime.sh`
+- Added `scripts/restore-latest-kde-runtime.sh`
+- Documented a temporary workaround that rolls back `org.kde.Platform//6.10` to a known working commit
+- Added verification steps for PySide6 imports inside the Vish Flatpak environment
+- Added instructions to revert the workaround once the upstream runtime is fixed
+
+## Notes
+
+This is intended as a temporary workaround for users affected by a Flatpak KDE runtime issue. It does not change Vish source code or application behavior.
+
+Known working runtime commit:
+
+```text
+a0fd8b396dc57700e0f805b2114d3925aa4aa72b10aa7b53cce4ab23c5bc68ac
+```

--- a/README-FIX.md
+++ b/README-FIX.md
@@ -1,0 +1,43 @@
+# Vish Flatpak PySide6 Runtime Workaround
+
+This PR adds troubleshooting documentation and helper scripts for a Flatpak runtime issue that can prevent Vish from starting with PySide6 import errors.
+
+## Added files
+
+```text
+docs/troubleshooting.md
+scripts/fix-pyside6-runtime.sh
+scripts/restore-latest-kde-runtime.sh
+```
+
+## What this fixes
+
+Some users may see Vish fail to start with errors like:
+
+```text
+ImportError: could not import module 'PySide6.QtGui'
+```
+
+or:
+
+```text
+ImportError: could not import module 'PySide6.QtCore'
+```
+
+The documented workaround rolls back `org.kde.Platform//6.10` to a known working commit.
+
+## Script usage
+
+Apply the workaround:
+
+```bash
+chmod +x scripts/fix-pyside6-runtime.sh
+./scripts/fix-pyside6-runtime.sh
+```
+
+Restore the latest KDE runtime after the upstream issue is fixed:
+
+```bash
+chmod +x scripts/restore-latest-kde-runtime.sh
+./scripts/restore-latest-kde-runtime.sh
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,124 @@
+# Troubleshooting
+
+## Flatpak: `ImportError: could not import module 'PySide6.QtGui'`
+
+### Symptoms
+
+When launching Vish through Flatpak, the application may fail to start with an error similar to:
+
+```text
+Traceback (most recent call last):
+  File "/app/share/vish/main.py", line 11, in <module>
+    from PySide6.QtWidgets import ...
+ImportError: could not import module 'PySide6.QtGui'
+```
+
+In some cases, the error may reference `PySide6.QtCore` instead:
+
+```text
+ImportError: could not import module 'PySide6.QtCore'
+```
+
+The problem can also be reproduced with:
+
+```bash
+flatpak run --command=python3 io.github.lluciocc.Vish \
+  -c "from PySide6.QtGui import QGuiApplication"
+```
+
+### Cause
+
+This issue is not caused by Vish itself, Hyprland, or a specific Linux distribution.
+
+The failure appears to be related to a problematic version of the Flatpak KDE runtime `org.kde.Platform//6.10`, which can prevent PySide6 modules such as `PySide6.QtCore` and `PySide6.QtGui` from loading correctly inside the Flatpak environment.
+
+Because Vish uses PySide6, the application may fail before the main window is created.
+
+### Workaround
+
+A temporary workaround is to roll back the KDE runtime to a known working commit:
+
+```text
+a0fd8b396dc57700e0f805b2114d3925aa4aa72b10aa7b53cce4ab23c5bc68ac
+```
+
+Run:
+
+```bash
+flatpak update \
+  --commit=a0fd8b396dc57700e0f805b2114d3925aa4aa72b10aa7b53cce4ab23c5bc68ac \
+  org.kde.Platform//6.10
+```
+
+Then launch Vish again:
+
+```bash
+flatpak run io.github.lluciocc.Vish
+```
+
+### Automated workaround script
+
+This repository includes an optional helper script:
+
+```bash
+scripts/fix-pyside6-runtime.sh
+```
+
+It checks whether Flatpak, Vish, and the required KDE runtime are available, applies the rollback, and verifies that PySide6 can be imported successfully.
+
+Usage:
+
+```bash
+chmod +x scripts/fix-pyside6-runtime.sh
+./scripts/fix-pyside6-runtime.sh
+```
+
+### Verifying the fix
+
+After applying the workaround, this command should run without errors:
+
+```bash
+flatpak run --command=python3 io.github.lluciocc.Vish \
+  -c "from PySide6.QtCore import Qt; from PySide6.QtGui import QGuiApplication; print('PySide6 OK')"
+```
+
+Expected output:
+
+```text
+PySide6 OK
+```
+
+If the command succeeds, Vish should launch normally.
+
+### Reverting the workaround
+
+Once the KDE Flatpak runtime is fixed upstream, return to the latest runtime version with:
+
+```bash
+flatpak update org.kde.Platform//6.10
+```
+
+Or use the included helper script:
+
+```bash
+chmod +x scripts/restore-latest-kde-runtime.sh
+./scripts/restore-latest-kde-runtime.sh
+```
+
+### Affected systems
+
+Since the issue originates from the Flatpak runtime, it may affect any Linux distribution using Vish through Flatpak with the affected KDE runtime, including but not limited to:
+
+- Arch Linux
+- EndeavourOS
+- CachyOS
+- Manjaro
+- Fedora
+- Linux Mint
+- Ubuntu
+- Debian
+- openSUSE
+
+### Notes for maintainers
+
+This is intended as a temporary workaround, not a permanent application-level fix. Once the affected runtime is fixed upstream, users should update `org.kde.Platform//6.10` normally and stop using the pinned commit.

--- a/scripts/fix-pyside6-runtime.sh
+++ b/scripts/fix-pyside6-runtime.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNTIME="org.kde.Platform//6.10"
+APP_ID="io.github.lluciocc.Vish"
+GOOD_COMMIT="a0fd8b396dc57700e0f805b2114d3925aa4aa72b10aa7b53cce4ab23c5bc68ac"
+
+print_header() {
+    echo "=========================================="
+    echo " Vish Flatpak PySide6 runtime workaround"
+    echo "=========================================="
+    echo
+}
+
+error() {
+    echo "[ERROR] $*" >&2
+}
+
+info() {
+    echo "[INFO] $*"
+}
+
+success() {
+    echo "[SUCCESS] $*"
+}
+
+warn() {
+    echo "[WARNING] $*"
+}
+
+print_header
+
+if ! command -v flatpak >/dev/null 2>&1; then
+    error "Flatpak is not installed."
+    exit 1
+fi
+
+if ! flatpak info "$RUNTIME" >/dev/null 2>&1; then
+    error "Required runtime $RUNTIME was not found."
+    echo
+    echo "Install or update Vish from Flathub first:"
+    echo "    flatpak install flathub $APP_ID"
+    exit 1
+fi
+
+if ! flatpak info "$APP_ID" >/dev/null 2>&1; then
+    error "Application $APP_ID is not installed."
+    echo
+    echo "Install it with:"
+    echo "    flatpak install flathub $APP_ID"
+    exit 1
+fi
+
+info "Applying rollback for $RUNTIME to the known working commit:"
+echo "$GOOD_COMMIT"
+echo
+
+if flatpak --user info "$RUNTIME" >/dev/null 2>&1; then
+    info "Detected user installation of $RUNTIME."
+    flatpak --user update \
+        --commit="$GOOD_COMMIT" \
+        "$RUNTIME" \
+        -y
+else
+    info "Detected system installation of $RUNTIME. Administrator privileges may be required."
+    sudo flatpak update \
+        --commit="$GOOD_COMMIT" \
+        "$RUNTIME" \
+        -y
+fi
+
+echo
+info "Testing PySide6 imports inside the Vish Flatpak environment..."
+
+if flatpak run --command=python3 "$APP_ID" \
+    -c "from PySide6.QtCore import Qt; from PySide6.QtGui import QGuiApplication; print('PySide6 OK')" >/dev/null 2>&1
+then
+    success "PySide6 loaded successfully."
+    echo
+    echo "You can now launch Vish with:"
+    echo "    flatpak run $APP_ID"
+else
+    warn "The rollback was applied, but the PySide6 import test still failed."
+    warn "There may be another issue besides the KDE Flatpak runtime."
+    echo
+    echo "Try running the test manually to inspect the full error:"
+    echo "    flatpak run --command=python3 $APP_ID -c \"from PySide6.QtCore import Qt; from PySide6.QtGui import QGuiApplication; print('PySide6 OK')\""
+    exit 1
+fi

--- a/scripts/restore-latest-kde-runtime.sh
+++ b/scripts/restore-latest-kde-runtime.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNTIME="org.kde.Platform//6.10"
+
+if ! command -v flatpak >/dev/null 2>&1; then
+    echo "[ERROR] Flatpak is not installed." >&2
+    exit 1
+fi
+
+if ! flatpak info "$RUNTIME" >/dev/null 2>&1; then
+    echo "[ERROR] Runtime $RUNTIME was not found." >&2
+    exit 1
+fi
+
+if flatpak --user info "$RUNTIME" >/dev/null 2>&1; then
+    flatpak --user update "$RUNTIME" -y
+else
+    sudo flatpak update "$RUNTIME" -y
+fi
+
+echo "[SUCCESS] $RUNTIME was updated to the latest available version."


### PR DESCRIPTION
## Summary

This PR adds troubleshooting documentation for a startup issue affecting some Flatpak users.

The problem manifests as:

```text
ImportError: could not import module 'PySide6.QtGui'
```

The issue appears to be related to specific versions of ```org.kde.Platform//6.10```

## Changes
- Added troubleshooting documentation
- Added workaround script for affected users
- Added script to restore the latest KDE runtime
- Documented verification and recovery steps

## Tested on
- Arch Linux
- Hyprland
- Flatpak
- Vish 1.1.3

